### PR TITLE
Multiple Parts-Per-Rank

### DIFF
--- a/io-mpi.c
+++ b/io-mpi.c
@@ -233,7 +233,7 @@ void io_load_checkpoint(char * master_filename) {
     MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
     for (cur_part = 0; cur_part < g_io_partitions_on_rank; cur_part++){
         int data_count = my_partitions[cur_part].lp_count;
-        MPI_File_read_at_all(fh, offset, &model_sizes[index], data_count, MPI_UNSIGNED_LONG, &status);
+        MPI_File_read_at(fh, offset, &model_sizes[index], data_count, MPI_UNSIGNED_LONG, &status);
         index += data_count;
         offset += (long long) data_count * sizeof(size_t);
     }

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -43,8 +43,9 @@ void io_register_model_version (char *sha1) {
 }
 
 tw_event * io_event_grab(tw_pe *pe) {
-    if (!l_io_init_flag) {
+    if (!l_io_init_flag || g_io_events_buffered_per_rank == 0) {
       // the RIO system has not been initialized
+      // or we are not buffering events
       return pe->abort_event;
     }
 
@@ -412,7 +413,7 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
         offset += (long long) sum_size;
     }
 
-    MPI_Comm_free(file_comm);
+    MPI_Comm_free(&file_comm);
 
     int amode;
     if (append_flag) {

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -293,8 +293,6 @@ void io_store_checkpoint(char * master_filename) {
     int mpi_rank = g_tw_mynode;
     int number_of_mpitasks = tw_nnodes();
 
-    // ASSUMPTION: A checkpoint writes LP data (only)
-    // TODO: support event data writing
     assert(g_io_number_of_files != 0 && g_io_number_of_partitions != 0 && "Error: IO variables not set: # of file or # of parts\n");
 
     if (g_io_partitions_on_rank > 1) {

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -208,24 +208,15 @@ void io_load_checkpoint(char * master_filename) {
 
     io_partition my_partitions[g_io_partitions_on_rank];
 
-    // printf("Rand %d loading metadata (%d on rank, offset part %d) \n", mpi_rank, g_io_partitions_on_rank, g_io_partitions_offset);
     sprintf(filename, "%s.mh", master_filename);
     MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
 	MPI_File_read_at_all(fh, offset, &my_partitions, g_io_partitions_on_rank, MPI_IO_PART, &status);
     MPI_File_close(&fh);
-    if (mpi_rank == -1) {
-        for (i = 0; i < g_io_partitions_on_rank; i++) {
-            printf("%d:\t%d\t%d\t%d\t%d\t%d\t%d\n", mpi_rank, my_partitions[i].part, my_partitions[i].file, my_partitions[i].offset, my_partitions[i].size, my_partitions[i].lp_count, my_partitions[i].ev_count);
-        }
-    }
 
     // error check
     int count_sum = 0;
     for (i = 0; i < g_io_partitions_on_rank; i++) {
         count_sum += my_partitions[i].lp_count;
-    }
-    if (count_sum != g_tw_nlp) {
-        printf("Rank %d found %d lps in the partitions (expected %d)\n", mpi_rank, count_sum, g_tw_nlp);
     }
     assert(count_sum == g_tw_nlp && "ERROR: wrong number of LPs in partitions");
 
@@ -237,7 +228,6 @@ void io_load_checkpoint(char * master_filename) {
     size_t model_sizes[g_tw_nlp];
     int index = 0;
 
-    printf("Rand %d loading lp sizes\n", mpi_rank);
     sprintf(filename, "%s.lp", master_filename);
     MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
     for (i = 0; i < g_io_partitions_on_rank; i++){
@@ -258,7 +248,6 @@ void io_load_checkpoint(char * master_filename) {
     MPI_Comm file_comm;
     int all_lp_i = 0;
     for (cur_part = 0; cur_part < g_io_partitions_on_rank; cur_part++) {
-        printf("Rank %ld reading file %d part %d\n", g_tw_mynode, my_partitions[cur_part].file, my_partitions[cur_part].part);
         // Read file
         char buffer[my_partitions[cur_part].size];
         void * b = buffer;

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -454,7 +454,7 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
     MPI_File_close(&fh);
 
     // WRITE READ ME
-    if (mpi_rank == 0) {
+    if (mpi_rank == 0 && (!append_flag || data_file_number == 0) ) {
         FILE *file;
         sprintf(filename, "%s.read-me.txt", master_filename);
         file = fopen(filename, "w");
@@ -473,8 +473,13 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
 #endif
         fprintf(file, "MODEL Version:\t%s\n", model_version);
         fprintf(file, "Checkpoint:\t%s\n", master_filename);
-        fprintf(file, "Data Files:\t%d\n", g_io_number_of_files);
-        fprintf(file, "Partitions:\t%d\n", g_io_number_of_partitions);
+        if (append_flag) {
+            fprintf(file, "Data Files:\t%d\n", g_io_number_of_files);
+            fprintf(file, "Partitions:\t%d\n", g_io_number_of_partitions);
+        } else {
+            fprintf(file, "Data Files:\t%d+?\n", g_io_number_of_files);
+            fprintf(file, "Partitions:\t%d+?\n", g_io_number_of_partitions);
+        }
 #ifdef RAND_NORMAL
         fprintf(file, "RAND_NORMAL\tON\n");
 #else

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -208,6 +208,7 @@ void io_load_checkpoint(char * master_filename) {
     sprintf(filename, "%s.mh", master_filename);
     MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
 	MPI_File_read_at_all(fh, offset, &my_partitions, g_io_partitions_on_rank, MPI_IO_PART, &status);
+    MPI_File_close(&fh);
 
     // error check
     int count_sum = 0;
@@ -220,17 +221,18 @@ void io_load_checkpoint(char * master_filename) {
     offset = (long long) 0;
     long long contribute = (long long) g_tw_nlp;
     MPI_Exscan(&contribute, &offset, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
-    offset += (long long) (sizeof(io_partition) * g_io_number_of_partitions);
 
     size_t model_sizes[g_tw_nlp];
     int index = 0;
+
+    sprintf(filename, "%s.lp", master_filename);
+    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
     for (i = 0; i < g_io_partitions_on_rank; i++){
         int data_count = my_partitions[i].lp_count;
         MPI_File_read_at_all(fh, offset, &model_sizes[index], data_count, MPI_UNSIGNED_LONG, &status);
         index += data_count;
         offset += (long long) data_count;
     }
-
     MPI_File_close(&fh);
 
     // for (i = 0; i < g_io_partitions_on_rank; i++) {

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -230,7 +230,7 @@ void io_load_checkpoint(char * master_filename) {
     MPI_Exscan(&contribute, &offset, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
     offset *= sizeof(size_t);
 
-    size_t model_sizes[g_tw_nlp];
+    size_t * model_sizes = (size_t *) calloc(g_tw_nlp, sizeof(size_t));
     int index = 0;
 
     sprintf(filename, "%s.lp", master_filename);
@@ -287,6 +287,8 @@ void io_load_checkpoint(char * master_filename) {
             tw_eventq_push(&g_io_buffered_events, ev);
         }
     }
+
+    free(model_sizes);
 
     return;
 }

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -409,9 +409,7 @@ void io_store_multiple_partitions(char * master_filename) {
 
         // Write
         // in this case each MPI rank gets its own file
-        int file_number = mpi_rank;
         int file_position = 0;
-        MPI_Comm_split(MPI_COMM_WORLD, file_number, file_position, &file_comm);
         MPI_File_open(file_comm, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
         MPI_File_write_at_all(fh, offset, &buffer, sum_size, MPI_BYTE, &status);
         MPI_File_close(&fh);

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -398,8 +398,8 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
         // Write
         // in this case each MPI rank gets its own file
         int file_position = 0;
-        MPI_File_open(file_comm, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
-        MPI_File_write_at_all(fh, offset, &buffer, sum_size, MPI_BYTE, &status);
+        MPI_File_open(file_comm, filename, MPI_MODE_CREATE | MPI_MODE_UNIQUE_OPEN | MPI_MODE_WRONLY | MPI_MODE_APPEND, MPI_INFO_NULL, &fh);
+        MPI_File_write(fh, &buffer, sum_size, MPI_BYTE, &status);
         MPI_File_close(&fh);
 
         my_partitions[cur_kp].part = cur_kp;
@@ -414,9 +414,9 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
 
     int amode;
     if (append_flag) {
-        amode = MPI_MODE_CREATE | MPI_MODE_RDWR | MPI_MODE_APPEND;
+        amode = MPI_MODE_CREATE | MPI_MODE_UNIQUE_OPEN | MPI_MODE_RDWR | MPI_MODE_APPEND;
     } else {
-        amode = MPI_MODE_CREATE | MPI_MODE_RDWR;
+        amode = MPI_MODE_CREATE | MPI_MODE_UNIQUE_OPEN | MPI_MODE_RDWR;
     }
 
     // Write Metadata

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -444,7 +444,10 @@ void io_store_multiple_partitions(char * master_filename) {
     MPI_File_write_at_all(fh, offset, all_lp_sizes, g_tw_nlp, MPI_UNSIGNED_LONG, &status);
     MPI_File_close(&fh);
 
-    // TODO: delete all model size arrays
+    // delete all model size arrays (calloc'd)
+    for (i = 0; i < g_tw_nkp; i++) {
+        delete all_lp_sizes[i];
+    }
 
     // WRITE READ ME
     if (mpi_rank == 0) {

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -224,6 +224,7 @@ void io_load_checkpoint(char * master_filename) {
     offset = (long long) 0;
     long long contribute = (long long) g_tw_nlp;
     MPI_Exscan(&contribute, &offset, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
+    offset *= sizeof(size_t);
 
     size_t model_sizes[g_tw_nlp];
     int index = 0;
@@ -234,7 +235,7 @@ void io_load_checkpoint(char * master_filename) {
         int data_count = my_partitions[i].lp_count;
         MPI_File_read_at_all(fh, offset, &model_sizes[index], data_count, MPI_UNSIGNED_LONG, &status);
         index += data_count;
-        offset += (long long) data_count;
+        offset += (long long) data_count * sizeof(size_t);
     }
     MPI_File_close(&fh);
 

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -194,7 +194,7 @@ void io_load_checkpoint(char * master_filename) {
 
     MPI_File fh;
     MPI_Status status;
-    char filename[100];
+    char filename[257];
 
     // Read MH
 

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -134,7 +134,7 @@ void io_read_master_header(char * master_filename) {
     fscanf(master_header, "%d %d", &num_files, &num_partitions);
 
     if (!l_io_init_flag) {
-    	io_init(num_files, num_partitions);
+    	io_init_global(num_files, num_partitions);
     }
 
     assert(num_files == g_io_number_of_files && "Error: Master Header indicated a different number of files than was previously allocated\n");

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -438,6 +438,10 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
     MPI_File_write_at_all(fh, offset, all_lp_sizes, g_tw_nlp, MPI_UNSIGNED_LONG, &status);
     MPI_File_close(&fh);
 
+    if (append_flag == 1) {
+        printf("%d parts written\n", g_io_partitions_on_rank);
+    }
+
     // WRITE READ ME
     if (mpi_rank == 0 && (append_flag == 0 || data_file_number == 0) ) {
         FILE *file;

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -298,8 +298,9 @@ void io_store_checkpoint(char * master_filename) {
     assert(g_io_number_of_files != 0 && g_io_number_of_partitions != 0 && "Error: IO variables not set: # of file or # of parts\n");
 
     if (g_io_partitions_on_rank > 1) {
-        assert((g_tw_nkp % g_io_partitions_on_rank) == 0 && "Error: Writing a checkpoint with multiple partitions per rank with wrong number of KPs\n");
-        // TODO: lp to kp mapping??
+        // Assume each KP is becoming a partition
+        assert((g_tw_nkp == g_io_partitions_on_rank) && "Error: Writing a checkpoint with multiple partitions per rank with wrong number of KPs\n");
+    }
     }
 
     // Gather LP size data

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -424,6 +424,7 @@ void io_store_multiple_partitions(char * master_filename) {
         offset += (long long) sum_size;
     }
 
+    // Write Metadata
     MPI_Datatype MPI_IO_PART;
     MPI_Type_contiguous(io_partition_field_count, MPI_INT, &MPI_IO_PART);
     MPI_Type_commit(&MPI_IO_PART);
@@ -435,12 +436,14 @@ void io_store_multiple_partitions(char * master_filename) {
     sprintf(filename, "%s.mh", master_filename);
     MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
     MPI_File_write_at_all(fh, offset, &my_partitions, g_io_partitions_on_rank, MPI_IO_PART, &status);
+    MPI_File_close(&fh);
 
     // Write model size array
     offset = (long long) 0;
     MPI_Offset contribute = (long long) g_tw_nlp;
     MPI_Exscan(&contribute, &offset, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
-    offset += (long long) (sizeof(io_partition) * g_io_number_of_partitions);
+    sprintf(filename, "%s.lp", master_filename);
+    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_CREATE | MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
     MPI_File_write_at_all(fh, offset, all_lp_sizes, g_tw_nlp, MPI_UNSIGNED_LONG, &status);
     MPI_File_close(&fh);
 

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -338,7 +338,7 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
     MPI_Comm_split(MPI_COMM_WORLD, file_number, 0, &file_comm);
     MPI_Offset offset = (long long) 0;
 
-    char filename[100];
+    char filename[256];
     sprintf(filename, "%s.data-%d", master_filename, file_number);
 
     // ASSUMPTION FOR MULTIPLE PARTS-PER-RANK

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -231,8 +231,8 @@ void io_load_checkpoint(char * master_filename) {
 
     sprintf(filename, "%s.lp", master_filename);
     MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
-    for (i = 0; i < g_io_partitions_on_rank; i++){
-        int data_count = my_partitions[i].lp_count;
+    for (cur_part = 0; cur_part < g_io_partitions_on_rank; cur_part++){
+        int data_count = my_partitions[cur_part].lp_count;
         MPI_File_read_at_all(fh, offset, &model_sizes[index], data_count, MPI_UNSIGNED_LONG, &status);
         index += data_count;
         offset += (long long) data_count * sizeof(size_t);
@@ -256,7 +256,7 @@ void io_load_checkpoint(char * master_filename) {
 
         // Must use non-collectives, can't know status of other MPI-ranks
         MPI_File_open(MPI_COMM_SELF, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
-        MPI_File_read_at(fh, (long long) my_partitions[i].offset, b, my_partitions[i].size, MPI_BYTE, &status);
+        MPI_File_read_at(fh, (long long) my_partitions[cur_part].offset, buffer, my_partitions[cur_part].size, MPI_BYTE, &status);
         MPI_File_close(&fh);
 
         // Load Data

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -454,7 +454,7 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
     MPI_File_close(&fh);
 
     // WRITE READ ME
-    if (mpi_rank == 0 && (!append_flag || data_file_number == 0) ) {
+    if (mpi_rank == 0 && (append_flag == 0 || data_file_number == 0) ) {
         FILE *file;
         sprintf(filename, "%s.read-me.txt", master_filename);
         file = fopen(filename, "w");
@@ -473,7 +473,7 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
 #endif
         fprintf(file, "MODEL Version:\t%s\n", model_version);
         fprintf(file, "Checkpoint:\t%s\n", master_filename);
-        if (append_flag) {
+        if (append_flag == 0) {
             fprintf(file, "Data Files:\t%d\n", g_io_number_of_files);
             fprintf(file, "Partitions:\t%d\n", g_io_number_of_partitions);
         } else {

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -261,18 +261,10 @@ void io_load_checkpoint(char * master_filename) {
         sprintf(filename, "%s.data-%d", master_filename, my_partitions[cur_part].file);
 
         // Must use non-collectives, can't know status of other MPI-ranks
-<<<<<<< HEAD
         rc = MPI_File_open(MPI_COMM_SELF, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
         if (rc != 0) {
             printf("ERROR: could not MPI_File_open %s\n", filename);
         }
-=======
-
-    rc =     MPI_File_open(MPI_COMM_SELF, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
-    if (rc != 0) {
-        printf("ERROR: could not MPI_File_open %s\n", filename);
-    }
->>>>>>> b31e833e9547547981ccd91a59deea0b141af6df
         MPI_File_read_at(fh, (long long) my_partitions[cur_part].offset, buffer, my_partitions[cur_part].size, MPI_BYTE, &status);
         MPI_File_close(&fh);
 

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -239,11 +239,7 @@ void io_load_checkpoint(char * master_filename) {
     //         my_partitions[i].size, my_partitions[i].lp_count, my_partitions[i].ev_count);
     // }
 
-    // Now data files
-    for (i = 1; i < g_io_partitions_on_rank; i++) {
-        assert(my_partitions[i].file == my_partitions[0].file && "ERROR: Some rank has partitions spread across files\n");
-    }
-
+    // DATA FILES
     // Read file
     MPI_Comm file_comm;
     int file_number = my_partitions[0].file;

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -344,7 +344,6 @@ void io_store_multiple_partitions(char * master_filename) {
 
     // ASSUMPTION FOR MULTIPLE PARTS-PER-RANK
     // Each MPI-Rank gets its own file
-    g_io_partitions_on_rank = g_tw_nkp;
     io_partition my_partitions[g_io_partitions_on_rank];
 
     size_t all_lp_sizes[g_tw_nlp];

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -412,6 +412,8 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
         offset += (long long) sum_size;
     }
 
+    MPI_Comm_free(file_comm);
+
     int amode;
     if (append_flag) {
         amode = MPI_MODE_CREATE | MPI_MODE_UNIQUE_OPEN | MPI_MODE_RDWR | MPI_MODE_APPEND;

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -65,7 +65,7 @@ tw_event * io_event_grab(tw_pe *pe) {
         printf("WARNING: did not allocate enough events to RIO buffer\n");
         e = pe->abort_event;
     }
-    pe->stats.s_rio += (tw_clock_read() - start);
+    pe->stats.s_rio_load += (tw_clock_read() - start);
     return e;
 }
 

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -446,11 +446,6 @@ void io_store_multiple_partitions(char * master_filename) {
     MPI_File_write_at_all(fh, offset, all_lp_sizes, g_tw_nlp, MPI_UNSIGNED_LONG, &status);
     MPI_File_close(&fh);
 
-    // delete all model size arrays (calloc'd)
-    for (i = 0; i < g_tw_nkp; i++) {
-        delete all_lp_sizes[i];
-    }
-
     // WRITE READ ME
     if (mpi_rank == 0) {
         FILE *file;

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -301,6 +301,11 @@ void io_store_checkpoint(char * master_filename) {
         // Assume each KP is becoming a partition
         assert((g_tw_nkp == g_io_partitions_on_rank) && "Error: Writing a checkpoint with multiple partitions per rank with wrong number of KPs\n");
     }
+
+    // LOOP OVER EACH KP/PARTITION
+    int lp_on_kp_count[g_tw_nkp];
+    for (i = 0; i < g_tw_nkp; i++) {
+        lp_on_kp_count[i] = g_tw_kp[i]->lp_count;
     }
 
     // Gather LP size data

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -183,7 +183,7 @@ void process_metadata(char * data_block, int mpi_rank) {
 }
 
 void io_load_checkpoint(char * master_filename) {
-    int i, cur_part;
+    int i, cur_part, rc;
     int mpi_rank = g_tw_mynode;
     int number_of_mpitasks = tw_nnodes();
 

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -210,7 +210,7 @@ void io_load_checkpoint(char * master_filename) {
 
     // printf("Rand %d loading metadata (%d on rank, offset part %d) \n", mpi_rank, g_io_partitions_on_rank, g_io_partitions_offset);
     sprintf(filename, "%s.mh", master_filename);
-    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
+    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
 	MPI_File_read_at_all(fh, offset, &my_partitions, g_io_partitions_on_rank, MPI_IO_PART, &status);
     MPI_File_close(&fh);
     if (mpi_rank == -1) {
@@ -237,8 +237,9 @@ void io_load_checkpoint(char * master_filename) {
     size_t model_sizes[g_tw_nlp];
     int index = 0;
 
+    printf("Rand %d loading lp sizes\n", mpi_rank);
     sprintf(filename, "%s.lp", master_filename);
-    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
+    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
     for (i = 0; i < g_io_partitions_on_rank; i++){
         int data_count = my_partitions[i].lp_count;
         MPI_File_read_at_all(fh, offset, &model_sizes[index], data_count, MPI_UNSIGNED_LONG, &status);
@@ -439,7 +440,7 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
     offset = (long long) sizeof(io_partition) * g_io_partitions_on_rank * mpi_rank;
     sprintf(filename, "%s.mh", master_filename);
     MPI_File_open(MPI_COMM_WORLD, filename, amode, MPI_INFO_NULL, &fh);
-    MPI_File_write_at_all(fh, offset, &my_partitions, g_io_partitions_on_rank, MPI_IO_PART, &status);
+    MPI_File_write(fh, &my_partitions, g_io_partitions_on_rank, MPI_IO_PART, &status);
     MPI_File_close(&fh);
 
     // Write model size array
@@ -448,7 +449,7 @@ void io_store_multiple_partitions(char * master_filename, int append_flag, int d
     MPI_Exscan(&contribute, &offset, 1, MPI_LONG_LONG, MPI_SUM, MPI_COMM_WORLD);
     sprintf(filename, "%s.lp", master_filename);
     MPI_File_open(MPI_COMM_WORLD, filename, amode, MPI_INFO_NULL, &fh);
-    MPI_File_write_at_all(fh, offset, all_lp_sizes, g_tw_nlp, MPI_UNSIGNED_LONG, &status);
+    MPI_File_write(fh, all_lp_sizes, g_tw_nlp, MPI_UNSIGNED_LONG, &status);
     MPI_File_close(&fh);
 
     if (append_flag == 1) {

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -347,15 +347,15 @@ void io_store_multiple_partitions(char * master_filename) {
     g_io_partitions_on_rank = g_tw_nkp;
     io_partition my_partitions[g_io_partitions_on_rank];
 
-    size_t * all_lp_sizes[g_tw_nkp];
+    size_t all_lp_sizes[g_tw_nlp];
+    int all_lp_i = 0;
 
     for (cur_kp = 0; cur_kp < g_tw_nkp; cur_kp++) {
         int lps_on_kp = g_tw_kp[cur_kp]->lp_count;
 
         // Gather LP size data
         int lp_size = sizeof(io_lp_store);
-        size_t * model_sizes = (size_t *) calloc(lps_on_kp, sizeof(size_t));
-        all_lp_sizes[cur_kp] = model_sizes;
+        size_t model_sizes[lps_on_kp];
         int sum_model_size = 0;
 
         // always do this loop to allow for interleaved LP types in g_tw_lp
@@ -365,7 +365,9 @@ void io_store_multiple_partitions(char * master_filename) {
                 int lp_type_index = g_tw_lp_typemap(g_tw_lp[c]->gid);
                 model_sizes[i] = ((model_size_f)g_io_lp_types[lp_type_index].model_size)(g_tw_lp[c]->cur_state, g_tw_lp[c]);
                 sum_model_size += model_sizes[i];
+                all_lp_sizes[all_lp_i] = model_sizes[i];
                 i++;
+                all_lp_i++;
             }
         }
 

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -208,15 +208,24 @@ void io_load_checkpoint(char * master_filename) {
 
     io_partition my_partitions[g_io_partitions_on_rank];
 
+    // printf("Rand %d loading metadata (%d on rank, offset part %d) \n", mpi_rank, g_io_partitions_on_rank, g_io_partitions_offset);
     sprintf(filename, "%s.mh", master_filename);
     MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDWR, MPI_INFO_NULL, &fh);
 	MPI_File_read_at_all(fh, offset, &my_partitions, g_io_partitions_on_rank, MPI_IO_PART, &status);
     MPI_File_close(&fh);
+    if (mpi_rank == -1) {
+        for (i = 0; i < g_io_partitions_on_rank; i++) {
+            printf("%d:\t%d\t%d\t%d\t%d\t%d\t%d\n", mpi_rank, my_partitions[i].part, my_partitions[i].file, my_partitions[i].offset, my_partitions[i].size, my_partitions[i].lp_count, my_partitions[i].ev_count);
+        }
+    }
 
     // error check
     int count_sum = 0;
     for (i = 0; i < g_io_partitions_on_rank; i++) {
         count_sum += my_partitions[i].lp_count;
+    }
+    if (count_sum != g_tw_nlp) {
+        printf("Rank %d found %d lps in the partitions (expected %d)\n", mpi_rank, count_sum, g_tw_nlp);
     }
     assert(count_sum == g_tw_nlp && "ERROR: wrong number of LPs in partitions");
 
@@ -248,6 +257,7 @@ void io_load_checkpoint(char * master_filename) {
     MPI_Comm file_comm;
     int all_lp_i = 0;
     for (cur_part = 0; cur_part < g_io_partitions_on_rank; cur_part++) {
+        printf("Rank %ld reading file %d part %d\n", g_tw_mynode, my_partitions[cur_part].file, my_partitions[cur_part].part);
         // Read file
         char buffer[my_partitions[cur_part].size];
         void * b = buffer;

--- a/io-mpi.c
+++ b/io-mpi.c
@@ -210,7 +210,10 @@ void io_load_checkpoint(char * master_filename) {
     io_partition my_partitions[g_io_partitions_on_rank];
 
     sprintf(filename, "%s.mh", master_filename);
-    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
+    rc = MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
+    if (rc != 0) {
+        printf("ERROR: could not MPI_File_open %s\n", filename);
+    }
 	MPI_File_read_at_all(fh, offset, &my_partitions, g_io_partitions_on_rank, MPI_IO_PART, &status);
     MPI_File_close(&fh);
 
@@ -231,7 +234,10 @@ void io_load_checkpoint(char * master_filename) {
     int index = 0;
 
     sprintf(filename, "%s.lp", master_filename);
-    MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
+    rc = MPI_File_open(MPI_COMM_WORLD, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
+    if (rc != 0) {
+        printf("ERROR: could not MPI_File_open %s\n", filename);
+    }
     for (cur_part = 0; cur_part < g_io_partitions_on_rank; cur_part++){
         int data_count = my_partitions[cur_part].lp_count;
         MPI_File_read_at(fh, offset, &model_sizes[index], data_count, MPI_UNSIGNED_LONG, &status);
@@ -247,7 +253,6 @@ void io_load_checkpoint(char * master_filename) {
     // }
 
     // DATA FILES
-    MPI_Comm file_comm;
     int all_lp_i = 0;
     for (cur_part = 0; cur_part < g_io_partitions_on_rank; cur_part++) {
         // Read file
@@ -256,7 +261,11 @@ void io_load_checkpoint(char * master_filename) {
         sprintf(filename, "%s.data-%d", master_filename, my_partitions[cur_part].file);
 
         // Must use non-collectives, can't know status of other MPI-ranks
-        MPI_File_open(MPI_COMM_SELF, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
+
+    rc =     MPI_File_open(MPI_COMM_SELF, filename, MPI_MODE_RDONLY, MPI_INFO_NULL, &fh);
+    if (rc != 0) {
+        printf("ERROR: could not MPI_File_open %s\n", filename);
+    }
         MPI_File_read_at(fh, (long long) my_partitions[cur_part].offset, buffer, my_partitions[cur_part].size, MPI_BYTE, &status);
         MPI_File_close(&fh);
 

--- a/io.h
+++ b/io.h
@@ -49,6 +49,7 @@ void io_write_master_header(char * master_filename);
 void io_load_checkpoint(char * master_filename);
 void io_load_events(tw_pe * me);
 void io_store_checkpoint(char * master_filename);
+void io_store_multiple_partitions(char * master_filename, int append_flag, int data_file_number);
 
 // LP type map and function struct
 typedef void (*serialize_f)(void * state, void * buffer, tw_lp *lp);

--- a/io.h
+++ b/io.h
@@ -40,7 +40,8 @@ extern int g_io_events_buffered_per_rank;
 // ** API Functions, Types, and Variables ** //
 
 void io_register_model_version(char *sha1);
-void io_init(int num_files, int num_partitions);
+void io_init_global(int global_num_files, int global_num_partitions);
+void io_init_local(int local_num_partitions);
 void io_final();
 void io_read_master_header(char * master_filename);
 void io_write_master_header(char * master_filename);


### PR DESCRIPTION
Multiple parts-per-rank allows non-uniformity across the parts assigned to the ranks. Eventually this should be solidified (when someone fixes ROSS's mapping API).
